### PR TITLE
add support for circular references in actions

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "mocha": "^2.2.5"
   },
   "dependencies": {
-    "invariant": "^2.1.0"
+    "invariant": "^2.1.0",
+    "json-stringify-safe": "^5.0.1"
   }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,5 @@
 import invariant from 'invariant';
+import stringify from 'json-stringify-safe';
 import isImmutableDefault from './isImmutable';
 import trackForMutations from './trackForMutations';
 
@@ -46,7 +47,7 @@ export default function immutableStateInvariantMiddleware(isImmutable = isImmuta
         !result.wasMutated,
         INSIDE_DISPATCH_MESSAGE,
         (result.path || []).join('.'),
-        JSON.stringify(action)
+        stringify(action)
       );
 
       return dispatchedAction;

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -69,4 +69,19 @@ describe('immutableStateInvariantMiddleware', () => {
       dispatch({type: 'SOME_OTHER_ACTION'});
     }).toNotThrow();
   });
+
+  it('works correctly with circular references', () => {
+    const next = action => action;
+
+    const dispatch = middleware(next);
+
+    let x = {};
+    let y = {};
+    x.y = y;
+    y.x = x;
+
+    expect(() => {
+      dispatch({type: 'SOME_ACTION', x});
+    }).toNotThrow();
+  });
 });


### PR DESCRIPTION
We bumped into this issue while using this lib with [redux-router](https://github.com/rackt/redux-router).

It seems like redux-router dispatches actions with circular references which was throwing errors.

This PR uses [json-stringify-safe](https://www.npmjs.com/package/json-stringify-safe) to do the stringifying to prevent the error.