### PR TITLE
fix for broken tests?

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,10 @@
+language: node_js
+node_js:
+  - "0.12.0"
+  - "stable"
+script:
+  - npm test
+
+notifications:
+  email: false
+  

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # redux-immutable-state-invariant
 
+[![Build Status](https://travis-ci.org/leoasis/redux-immutable-state-invariant.png)](https://travis-ci.org/leoasis/redux-immutable-state-invariant)
+
 Redux middleware that spits an error on you when you try to mutate your state either inside a dispatch or between dispatches. **For development use only!**
 
 ## Why?

--- a/test/trackForMutations.spec.js
+++ b/test/trackForMutations.spec.js
@@ -96,7 +96,7 @@ describe('trackForMutations', () => {
         s.stuff.push(1);
         return s;
       },
-      path: ['stuff', 0]
+      path: ['stuff', '0']
     },
     'adding object to array': {
       getState: () => ({
@@ -106,7 +106,7 @@ describe('trackForMutations', () => {
         s.stuff.push({foo: 1, bar: 2});
         return s;
       },
-      path: ['stuff', 0]
+      path: ['stuff', '0']
     },
     'mutating previous state and returning new state': {
       getState: () => ({ counter: 0 }),


### PR DESCRIPTION
Hi @leoasis, when I forked and cloned this project to work on something (for which I will open another PR), I had failing tests locally. I think maybe these just slipped by since you don't have Travis (or another CI) running on the main repo. Can you verify that the change I've made - changing the expectation for `path` to provide array indices as strings, not integers - is correct?

I also added a Travis config and the build badge in the README.