### PR TITLE
add stateInvariantTestHelper named export

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -54,3 +54,10 @@ export default function immutableStateInvariantMiddleware(isImmutable = isImmuta
     };
   };
 }
+
+export function stateInvariantTestHelper(isImmutable = isImmutableDefault) {
+  return {
+    trackObj: (obj) => { return trackForMutations(isImmutable, obj); },
+    hasMutated: (tracked) => { return tracked.detectMutations().wasMutated; }
+  };
+}


### PR DESCRIPTION
Hi again @leoasis. This is the PR I referenced in #8 - the real reason I cloned to work on something and noticed the failing tests.

I first read about this project of yours in the redux docs, and recently it came up again for us at Tidepool. We don't particularly have a use for the middleware, but we *love* the ability to detect mutations recursively. We are quite obsessed with testing, and one of the things we test in all of our reducer tests is that we're not mutating the initial state (for any reducer that operates on a slice of state that's an object or array). So this PR adds a named export `stateInvariantTestHelper` providing an interface to track an initial state fixture (`trackObj`) in a test and then a function (`hasMutated`) to query for whether the object has been mutated at any level in a test expectation.

We use it like this:
```
    it('should not mutate object in handling SET_BLIP_VIEW_DATA_URL', () => {
      let initialState = {};
      const tracked = stateInvariantTestHelper.trackObj(initialState);
      let finalState = misc.blipUrls(initialState, {
        type: actionTypes.SET_BLIP_VIEW_DATA_URL,
        payload: actionPayload
      });
      expect(stateInvariantTestHelper.hasMutated(tracked)).to.be.false;
    });
```

Before I go any further, I wanted to find out if this is a change/PR that interests you since obviously it expands the use cases that this repo would be supporting. If you are interested, I'm happy to discuss the particulars of the new export's interface (I'm not quite sure yet that it's ideal), add some tests, and update the README with the usage. If you're not interested, just let me know, and we at Tidepool will then probably change the name of our fork, remove the middleware-specific code, and publish to npm separately just with the test helper.