### PR TITLE
Add .babelrc to .npmignore for React Native compatibility

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,2 +1,3 @@
 src
 test
+.babelrc


### PR DESCRIPTION
As discussed here: https://github.com/facebook/react-native/issues/4062 , having .babelrc publish to NPM conflicts with parent projects that are using babel 6.