### PR TITLE
updated links to redux.js.org

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Redux middleware that spits an error on you when you try to mutate your state ei
 
 ## Why?
 
-Because [you're not allowed to mutate your state in your reducers](http://rackt.github.io/redux/docs/Troubleshooting.html#never-mutate-reducer-arguments)!. And by extension, you shouldn't mutate them either outside. In order to change state in your app, you should always return a new instance of your state with the changes.
+Because [you're not allowed to mutate your state in your reducers](http://redux.js.org/docs/Troubleshooting.html#never-mutate-reducer-arguments)!. And by extension, you shouldn't mutate them either outside. In order to change state in your app, you should always return a new instance of your state with the changes.
 
 If you're using a library such as `Immutable.js`, this is automatically done for you since the structures provided by that library don't allow you to mutate them (as long as you don't have mutable stuff as values in those collections). However, if you're using regular objects and arrays, you should be careful to avoid mutations.
 

--- a/src/index.js
+++ b/src/index.js
@@ -6,13 +6,13 @@ import trackForMutations from './trackForMutations';
 const BETWEEN_DISPATCHES_MESSAGE = [
   'A state mutation was detected between dispatches, in the path `%s`.',
   'This may cause incorrect behavior.',
-  '(http://rackt.github.io/redux/docs/Troubleshooting.html#never-mutate-reducer-arguments)'
+  '(http://redux.js.org/docs/Troubleshooting.html#never-mutate-reducer-arguments)'
 ].join(' ');
 
 const INSIDE_DISPATCH_MESSAGE = [
   'A state mutation was detected inside a dispatch, in the path: `%s`.',
   'Take a look at the reducer(s) handling the action %s.',
-  '(http://rackt.github.io/redux/docs/Troubleshooting.html#never-mutate-reducer-arguments)'
+  '(http://redux.js.org/docs/Troubleshooting.html#never-mutate-reducer-arguments)'
 ].join(' ');
 
 export default function immutableStateInvariantMiddleware(isImmutable = isImmutableDefault) {


### PR DESCRIPTION
The links are still pointing to `rackt.github.io`. I've changed them to `redux.js.org`.