### PR TITLE
NaN handling

### DIFF
--- a/src/trackForMutations.js
+++ b/src/trackForMutations.js
@@ -25,7 +25,7 @@ function detectMutations(isImmutable, trackedProperty, obj, sameParentRef = fals
 
   const sameRef = prevObj === obj;
 
-  if (sameParentRef && !sameRef) {
+  if (sameParentRef && !sameRef && !Number.isNaN(obj)) {
     return { wasMutated: true, path };
   }
 

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -84,4 +84,15 @@ describe('immutableStateInvariantMiddleware', () => {
       dispatch({type: 'SOME_ACTION', x});
     }).toNotThrow();
   });
+
+  it('works correctly with NaN', () => {
+    const next = action => action;
+
+    const dispatch = middleware(next);
+
+    state = {foo: NaN};
+    expect(() => {
+      dispatch({type: 'SOME_ACTION'});
+    }).toNotThrow();
+  })
 });

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -84,15 +84,4 @@ describe('immutableStateInvariantMiddleware', () => {
       dispatch({type: 'SOME_ACTION', x});
     }).toNotThrow();
   });
-
-  it('works correctly with NaN', () => {
-    const next = action => action;
-
-    const dispatch = middleware(next);
-
-    state = {foo: NaN};
-    expect(() => {
-      dispatch({type: 'SOME_ACTION'});
-    }).toNotThrow();
-  })
 });

--- a/test/trackForMutations.spec.js
+++ b/test/trackForMutations.spec.js
@@ -226,6 +226,10 @@ describe('trackForMutations', () => {
       fn: (s) => {
         return {...s, foo: {}};
       }
+    },
+    'having a NaN in the state': {
+      getState: () => ({ a:NaN, b: Number.NaN }),
+      fn: (s) => s
     }
   };
 


### PR DESCRIPTION
Although it's rare, you can end up with a NaN in your state if it's the output of a mathematical function.
NaN is tricky:
`NaN === NaN;        // false`
`Number.NaN === NaN; // false`
`Number.isNaN(NaN);  // true`
This PR prevents the middleware from throwing if there is a NaN in the state