### PR TITLE
ignore mutation detection for specified branches

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,11 +48,11 @@ Then if you're doing things correctly, you should see nothing different. But if 
 
 #### `immutableStateInvariantMiddleware({ isImmutable, ignore })`
 
-middleware creation function and default export. supports an optional `object` argument used customize middleware behavior with supported options.
+Middleware creation function and default export. Supports an optional `object` argument to customize middleware behavior with supported options.
 
 **Parameters**
 
-- **isImmutable** `function` - override default "isImmutable" implementation (see: src/isImmutable.js). function must accept a single argument and return `true` if the value should be considered immutable, `false` otherwise.
+- **isImmutable** `function` - override default "isImmutable" implementation (see: `src/isImmutable.js`). function must accept a single argument and return `true` if the value should be considered immutable, `false` otherwise.
 
     ```js
     // example: use a custom `isImmutable` implementation

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ middleware creation function and default export. supports an optional `object` a
 - **ignore** `string[]` - specify branch(es) of state to ignore when detecting for mutations. elements of array should be dot-separated "path" strings that match named nodes from the root state.
 
     ```js
-    // example: ignore mutation detection along the 'foo' & 'bar.thingsToIgnore' branches of state
+    // example: ignore mutation detection along the 'foo' & 'bar.thingsToIgnore' branches
     const mw = immutableStateInvariantMiddleware({ ignore: ['foo', 'bar.thingsToIgnore'] })
     ```
 

--- a/README.md
+++ b/README.md
@@ -43,3 +43,26 @@ const store = createStore(
 ```
 
 Then if you're doing things correctly, you should see nothing different. But if you don't, that is, if you're mutating your data somewhere in your app either in a dispatch or between dispatches, an error will be thrown with a (hopefully) descriptive message.
+
+## API
+
+#### `immutableStateInvariantMiddleware({ isImmutable, ignore })`
+
+middleware creation function and default export. supports an optional `object` argument used customize middleware behavior with supported options.
+
+**Parameters**
+
+- **isImmutable** `function` - override default "isImmutable" implementation (see: src/isImmutable.js). function must accept a single argument and return `true` if the value should be considered immutable, `false` otherwise.
+
+    ```js
+    // example: use a custom `isImmutable` implementation
+    const mw = immutableStateInvariantMiddleware({ isImmutable: customIsImmutable })
+    ```
+- **ignore** `string[]` - specify branch(es) of state to ignore when detecting for mutations. elements of array should be dot-separated "path" strings that match named nodes from the root state.
+
+    ```js
+    // example: ignore mutation detection along the 'foo' & 'bar.thingsToIgnore' branches of state
+    const mw = immutableStateInvariantMiddleware({ ignore: ['foo', 'bar.thingsToIgnore'] })
+    ```
+
+Returns: `function` - the middleware function

--- a/src/index.js
+++ b/src/index.js
@@ -15,11 +15,11 @@ const INSIDE_DISPATCH_MESSAGE = [
   '(http://redux.js.org/docs/Troubleshooting.html#never-mutate-reducer-arguments)'
 ].join(' ');
 
-export default function immutableStateInvariantMiddleware(
-  isImmutable = isImmutableDefault,
-  options = {},
-) {
-  const { ignore } = options
+export default function immutableStateInvariantMiddleware(options = {}) {
+  const {
+    isImmutable = isImmutableDefault,
+    ignore
+  } = options
   const track = trackForMutations.bind(null, isImmutable, ignore);
 
   return ({getState}) => {

--- a/src/index.js
+++ b/src/index.js
@@ -15,8 +15,12 @@ const INSIDE_DISPATCH_MESSAGE = [
   '(http://redux.js.org/docs/Troubleshooting.html#never-mutate-reducer-arguments)'
 ].join(' ');
 
-export default function immutableStateInvariantMiddleware(isImmutable = isImmutableDefault) {
-  const track = trackForMutations.bind(null, isImmutable);
+export default function immutableStateInvariantMiddleware(
+  isImmutable = isImmutableDefault,
+  options = {},
+) {
+  const { ignore } = options
+  const track = trackForMutations.bind(null, isImmutable, ignore);
 
   return ({getState}) => {
     let state = getState();

--- a/src/trackForMutations.js
+++ b/src/trackForMutations.js
@@ -14,7 +14,8 @@ function trackProperties(isImmutable, ignore = [], obj, path = []) {
     tracked.children = {};
 
     for (const key in obj) {
-      if (ignore.length && ignore.includes([ ...path, key].join('.'))) {
+      const childPath = path.concat(key);
+      if (ignore.length && ignore.indexOf(childPath.join('.')) !== -1) {
         continue;
       }
 
@@ -22,7 +23,7 @@ function trackProperties(isImmutable, ignore = [], obj, path = []) {
         isImmutable,
         ignore,
         obj[key],
-        path.concat(key)
+        childPath
       );
     }
   }
@@ -54,7 +55,8 @@ function detectMutations(isImmutable, ignore = [], trackedProperty, obj, samePar
   const keys = Object.keys(keysToDetect);
   for (let i = 0; i < keys.length; i++) {
     const key = keys[i];
-    if (ignore.length && ignore.includes([ ...path, key].join('.'))) {
+    const childPath = path.concat(key);
+    if (ignore.length && ignore.indexOf(childPath.join('.')) !== -1) {
       continue;
     }
 
@@ -64,7 +66,7 @@ function detectMutations(isImmutable, ignore = [], trackedProperty, obj, samePar
       trackedProperty.children[key],
       obj[key],
       sameRef,
-      path.concat(key)
+      childPath
     );
 
     if (result.wasMutated) {

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -84,4 +84,23 @@ describe('immutableStateInvariantMiddleware', () => {
       dispatch({type: 'SOME_ACTION', x});
     }).toNotThrow();
   });
+
+  it('respects "ignore" option', () => {
+    const middlewareIgnore = (next) => {
+      return immutableStateInvariantMiddleware(undefined, {
+        ignore: ['foo.bar']
+      })({getState})(next);
+    }
+
+    const next = action => {
+      state.foo.bar.push(5);
+      return action;
+    };
+
+    const dispatch = middlewareIgnore(next);
+
+    expect(() => {
+      dispatch({type: 'SOME_ACTION'});
+    }).toNotThrow();
+  })
 });

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -85,6 +85,20 @@ describe('immutableStateInvariantMiddleware', () => {
     }).toNotThrow();
   });
 
+  it('respects "isImmutable" option', function () {
+    const isImmutable = (value) => true
+    const next = action => {
+      state.foo.bar.push(5);
+      return action;
+    };
+
+    const dispatch = middleware({ isImmutable })(next);
+
+    expect(() => {
+      dispatch({type: 'SOME_ACTION'});
+    }).toNotThrow();
+  })
+
   it('respects "ignore" option', () => {
     const next = action => {
       state.foo.bar.push(5);

--- a/test/trackForMutations.spec.js
+++ b/test/trackForMutations.spec.js
@@ -168,6 +168,17 @@ describe('trackForMutations', () => {
       },
       path: ['foo']
     },
+    'cannot ignore root state': {
+      getState: () => ({ foo: {} }),
+      fn: (s) => {
+        s.foo = {};
+        return s;
+      },
+      middlewareOptions: {
+        ignore: ['']
+      },
+      path: ['foo']
+    },
     'catching state mutation in non-ignored branch': {
       getState: () => ({
         foo: {

--- a/test/trackForMutations.spec.js
+++ b/test/trackForMutations.spec.js
@@ -279,16 +279,22 @@ describe('trackForMutations', () => {
           boo: {
             yah: [1, 2]
           }
-        }
+        },
+        stuff: [{a: 1}, {a: 2}]
       }),
       fn: (s) => {
         s.foo.bar.push(3);
         s.foo.boo.yah.push(3);
+        s.stuff[1].a = 3
         return s;
       },
     };
     const state = spec.getState();
-    const tracker = trackForMutations(isImmutable, ['foo.bar', 'foo.boo.yah'], state);
+    const tracker = trackForMutations(isImmutable, [
+      'foo.bar',
+      'foo.boo.yah',
+      'stuff.1',
+    ], state);
     const newState = spec.fn(state);
 
     expect(


### PR DESCRIPTION
I've been using `redux-immutable-state-invariant` for a while now and it's been really helpful :)

I ran across the following issue while looking into a way to deal with some performance problems when using this in development with a redux store that houses very large datasets: https://github.com/leoasis/redux-immutable-state-invariant/issues/20

Figured i'd take a stab at it, but let me know if I'm just making a mess :)

My use case doesn't actually use Immutable.js for any branches of state, but we store lots data that we receive from an API as normalized entities under specific paths (using `normalizr`: https://github.com/paularmstrong/normalizr).

When we need to test locally with large datasets, we found `redux-immutable-state-invariant` really made our app chug, so we would disable the mutation checking entirely.  I desired a way to turn "off" mutation detection via configuration so that we can keep detection enabled for most branches, while ignoring the problematic ones as needed.

These changes add an `options` argument to `immutableStateInvariantMiddleware`.  The only supported option right now is `ignore`, which can be an array of dot-separated "path" strings:
```javascript
// Any branch matching a path string will be skipped and report as "not mutated".
const mw = immutableStateInvariantMiddleware(undefined, {
  ignore: ['entities', 'foo.bar']
})
```

Some notes on implementation:

- This is kind of an opinionated implementation, so let me know if this seems problematic.
- Root state can _not_ be ignored this way.  Using empty string in `ignore` array won't match any branches of state.
- array indices can be ignored, but doesn't match familiar syntax
e.g. 'stuff.0' path string would ignore mutation detection for elt at `state.stuff[0]`

These changes also alter the function signature of the exported `trackForMutations` method, which could be a problem if people are using this method directly, outside of normal usage via `immutableStateInvariantMiddleware`, so this can be considered a breaking change in that respect.  Usage of `immutableStateInvariantMiddleware` should be backwards compatible.
