### PR TITLE
Add a logToConsoleOnly option

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,3 +65,4 @@ The default export is a factory to create the middleware. Supports an `options` 
       ]
     });
     ```
+- **logToConsoleOnly** `bool` - Only logs to console.error instead of throwing.  This is helpful if the current app is making many undesirable mutations and you plan to fix them gradually.

--- a/package.json
+++ b/package.json
@@ -23,7 +23,8 @@
     "coveralls": "2.12.0",
     "expect": "1.20.2",
     "istanbul": "0.4.5",
-    "mocha": "3.2.0"
+    "mocha": "3.2.0",
+    "sinon": "^4.0.0"
   },
   "dependencies": {
     "invariant": "^2.1.0",

--- a/src/index.js
+++ b/src/index.js
@@ -18,7 +18,8 @@ const INSIDE_DISPATCH_MESSAGE = [
 export default function immutableStateInvariantMiddleware(options = {}) {
   const {
     isImmutable = isImmutableDefault,
-    ignore
+    ignore,
+    logToConsoleOnly
   } = options
   const track = trackForMutations.bind(null, isImmutable, ignore);
 
@@ -34,11 +35,18 @@ export default function immutableStateInvariantMiddleware(options = {}) {
       // Track before potentially not meeting the invariant
       tracker = track(state);
 
-      invariant(
-        !result.wasMutated,
-        BETWEEN_DISPATCHES_MESSAGE,
-        (result.path || []).join('.')
-      );
+      if (logToConsoleOnly) {
+        result.wasMutated && console.error(
+          BETWEEN_DISPATCHES_MESSAGE,
+          (result.path || []).join('.')
+        );
+      } else {
+        invariant(
+          !result.wasMutated,
+          BETWEEN_DISPATCHES_MESSAGE,
+          (result.path || []).join('.')
+        );
+      }
 
       const dispatchedAction = next(action);
       state = getState();
@@ -46,13 +54,21 @@ export default function immutableStateInvariantMiddleware(options = {}) {
       result = tracker.detectMutations();
       // Track before potentially not meeting the invariant
       tracker = track(state);
-
-      result.wasMutated && invariant(
-        !result.wasMutated,
-        INSIDE_DISPATCH_MESSAGE,
-        (result.path || []).join('.'),
-        stringify(action)
-      );
+      
+      if (logToConsoleOnly) {
+        result.wasMutated && console.error(
+          INSIDE_DISPATCH_MESSAGE,
+          (result.path || []).join('.'),
+          stringify(action)
+        );
+      } else {
+        invariant(
+          !result.wasMutated,
+          INSIDE_DISPATCH_MESSAGE,
+          (result.path || []).join('.'),
+          stringify(action)
+        );
+      }
 
       return dispatchedAction;
     };

--- a/src/index.js
+++ b/src/index.js
@@ -62,7 +62,7 @@ export default function immutableStateInvariantMiddleware(options = {}) {
           stringify(action)
         );
       } else {
-        invariant(
+        result.wasMutated && invariant(
           !result.wasMutated,
           INSIDE_DISPATCH_MESSAGE,
           (result.path || []).join('.'),

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -125,7 +125,6 @@ describe('immutableStateInvariantMiddleware', () => {
     expect(() => {
       dispatch({type: 'SOME_ACTION'});
     }).toNotThrow();
-    expect(console.error.calledOnce).toEqual(true);
     expect(console.error.calledWith(sinon.match.any, sinon.match(new RegExp('foo\\.bar\\.3')))).toEqual(true);
     console.error.restore();
   });

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -112,9 +112,26 @@ describe('immutableStateInvariantMiddleware', () => {
       dispatch({type: 'SOME_ACTION'});
     }).toNotThrow();
   });
+});
+
+describe('immutableStateInvariantMiddleware with console logging', () => {
+  let state;
+  const getState = () => state;
+
+  function middleware(options) {
+    return immutableStateInvariantMiddleware(options)({getState});
+  }
+
+  beforeEach(() => {
+    sinon.spy(console, 'error');
+    state = {foo: {bar: [2, 3, 4], baz: 'baz'}};
+  });
+
+  afterEach(() => {
+    console.error.restore();
+  });
 
   it('logs if mutating inside the dispatch', () => {
-    sinon.spy(console, 'error');
     const next = action => {
       state.foo.bar.push(5);
       return action;
@@ -126,11 +143,9 @@ describe('immutableStateInvariantMiddleware', () => {
       dispatch({type: 'SOME_ACTION'});
     }).toNotThrow();
     expect(console.error.calledWith(sinon.match.any, sinon.match(new RegExp('foo\\.bar\\.3')))).toEqual(true);
-    console.error.restore();
   });
 
   it('logs if mutating between dispatches', () => {
-    sinon.spy(console, 'error');
     const next = action => action;
 
     const dispatch = middleware({ logToConsoleOnly: true })(next);
@@ -141,6 +156,5 @@ describe('immutableStateInvariantMiddleware', () => {
       dispatch({type: 'SOME_OTHER_ACTION'});
     }).toNotThrow();
     expect(console.error.calledWith(sinon.match.any, sinon.match(new RegExp('foo\\.bar\\.3')))).toEqual(true);
-    console.error.restore();
   });
 });


### PR DESCRIPTION
+- **logToConsoleOnly** `bool` - Only logs to console.error instead of throwing.  This is helpful if the current app is making many undesirable mutations and you plan to fix them gradually.