### PR TITLE
Use global isNaN to support IE11

### DIFF
--- a/src/trackForMutations.js
+++ b/src/trackForMutations.js
@@ -35,7 +35,7 @@ function detectMutations(isImmutable, ignore = [], trackedProperty, obj, samePar
 
   const sameRef = prevObj === obj;
 
-  if (sameParentRef && !sameRef && !Number.isNaN(obj)) {
+  if (sameParentRef && !sameRef && !isNaN(obj)) {
     return { wasMutated: true, path };
   }
 


### PR DESCRIPTION
This is to fix the Number.isNaN support issue on IE11 as reported on https://github.com/leoasis/redux-immutable-state-invariant/issues/36/ Same issue was observed by my.